### PR TITLE
Last Milestone 0.9 Issue

### DIFF
--- a/tests/VCardDBTest.php
+++ b/tests/VCardDBTest.php
@@ -268,23 +268,17 @@ class VCardDBTest extends PHPUnit_Extensions_Database_TestCase
     {
         $this->assertEquals( 0, $this->getConnection()->getRowCount('CONTACT'),
                              "Precondition" );
-
-        $expected = [
-                        'n_FirstName' => 'Fred',
-                        'n_LastName' => 'Jones',
-                        'adr_StreetAddress' => '47 Some Street',
-			'adr_Locality' => 'Birmingham',
-                        'adr_Region' => 'AL',
-                        'fn' => 'Fred Jones'
-                     ];
+        $n = ['FirstName'=>'Fred', 'LastName'=>'Jones'];
+        $adr = [
+            'StreetAddress'=>'47 Some Street',
+            'Locality'=>'Birmingham',
+            'Region'=>'AL'
+            ];
+        $fn = 'Fred Jones';
         $vcard = new VCard();
-	$vcard->fn = $expected['fn'];
-        $vcard->n($expected['n_FirstName'], 'FirstName');
-        $vcard->n($expected['n_LastName'], 'LastName');
-        $vcard->adr($expected['adr_StreetAddress'], 'StreetAddress');
-        $vcard->adr($expected['adr_Locality'], 'Locality');
-        $vcard->adr($expected['adr_Region'], 'Region');
-	$vcard->fn = $expected['fn'];
+	$vcard->fn = $fn;
+        $vcard->n = [$n];
+        $vcard->adr = [$adr];
 
         $contactID = $vcardDB->store($vcard);
         $this->assertEquals( 1, $this->getConnection()->getRowCount('CONTACT'),
@@ -297,9 +291,48 @@ class VCardDBTest extends PHPUnit_Extensions_Database_TestCase
             "After storing " . $contactID );
         $resultVCard = $vcardDB->fetchOne($contactID);
 
-        $this->compareVCards($vcard, $resultVCard);    	 
+        $this->compareVCards($vcard, $resultVCard);
+
+        return $vcardDB;
     } //testStoreAndRetrieveWAddress()
-    
+
+    /**
+     * @depends testStoreAndRetrieveWAddress
+     */
+    public function testStoreAndRetrieveWAddressType(VCardDB $vcardDB)
+    {
+        $this->assertEquals( 0, $this->getConnection()->getRowCount('CONTACT'),
+                             "Precondition" );
+        $n = ['FirstName'=>'Fred', 'LastName'=>'Jones'];
+        $adr = [
+            'StreetAddress'=>'47 Some Street',
+            'Locality'=>'Birmingham',
+            'Region'=>'AL',
+            'Type'=>['work']
+            ];
+        $fn = 'Fred Jones';
+        $vcard = new VCard();
+	$vcard->fn = $fn;
+        $vcard->n = [$n];
+        $vcard->adr = [$adr];
+
+        $contactID = $vcardDB->store($vcard);
+        $this->assertEquals( 1, $this->getConnection()->getRowCount('CONTACT'),
+                             "After storing " . $contactID );
+        $this->assertEquals( 1,
+            $this->getConnection()->getRowCount('CONTACT_MAIL_ADDRESS'),
+            "After storing " . $contactID );
+        $this->assertEquals( 1,
+            $this->getConnection()->getRowCount('CONTACT_REL_MAIL_ADDRESS'),
+            "After storing " . $contactID );
+        $this->assertEquals( 1,
+          $this->getConnection()->getRowCount('CONTACT_MAIL_ADDRESS_REL_TYPES'),
+            "After storing " . $contactID );
+        $resultVCard = $vcardDB->fetchOne($contactID);
+
+        $this->compareVCards($vcard, $resultVCard);    	 
+    } //testStoreAndRetrieveWAddressType()
+
     /**
      * @depends testStoreAndRetrieveVCard
      */

--- a/tests/VCardTest.php
+++ b/tests/VCardTest.php
@@ -169,11 +169,11 @@ class VCardTest extends PHPUnit_Framework_TestCase {
     	
     	$dDBinks = new vCard();
     	$dDBinks -> n($inputs['n_FirstName'], 'FirstName')
-    	-> n($inputs['n_LastName'], 'LastName')
-    	-> n($inputs['n_AdditionalNames'], 'AdditionalNames')
-    	-> org($inputs['org'], 'Name')
-    	-> fn($inputs['fn'])
-    	-> kind($inputs['kind']);
+            -> n($inputs['n_LastName'], 'LastName')
+            -> n($inputs['n_AdditionalNames'], 'AdditionalNames')
+            -> org($inputs['org'], 'Name')
+            -> fn($inputs['fn'])
+            -> kind($inputs['kind']);
 
     	return $dDBinks; 
     }
@@ -184,19 +184,18 @@ class VCardTest extends PHPUnit_Framework_TestCase {
      */
     public function getSeinarAPL()
     {
-    	$raithSeinar = new VCard();
     	$inputs = $this->getSeinarAPLInputs();
     
     	$seinarAPL = new VCard();
     	$seinarAPL -> org($inputs['org_Name'], 'Name')
-    	-> org($inputs['org_Unit1'], 'Unit1')
-    	-> org($inputs['org_Unit2'], 'Unit2')
-    	-> fn($inputs['fn'])
-    	-> logo($inputs['logo'])
-    	-> categories($inputs['category1'])
-    	-> categories($inputs['category2'])
-    	-> categories($inputs['category3'])
-    	-> kind($inputs['kind']);
+            -> org($inputs['org_Unit1'], 'Unit1')
+            -> org($inputs['org_Unit2'], 'Unit2')
+            -> fn($inputs['fn'])
+            -> logo($inputs['logo'])
+            -> categories($inputs['category1'])
+            -> categories($inputs['category2'])
+            -> categories($inputs['category3'])
+            -> kind($inputs['kind']);
     	return $seinarAPL;
     }
     	
@@ -209,14 +208,14 @@ class VCardTest extends PHPUnit_Framework_TestCase {
     	$raithSeinar = new VCard();
     	$inputs = $this->getRaithSeinarInputs();
     	
-    	$raithSeinar -> n('Raith', 'FirstName')
-    	-> n('Seinar', 'LastName')
-    	-> org('Seinar Fleet Systems', 'Name')
-    	-> title('CEO')
-    	-> fn('Raith Seinar')
-    	-> categories('military industrial')
-    	-> categories('empire')
-    	-> kind('individual');
+    	$raithSeinar -> n($inputs['n_FirstName'], 'FirstName')
+            -> n($inputs['n_LastName'], 'LastName')
+            -> org($inputs['org'], 'Name')
+            -> title($inputs['title'])
+            -> fn($inputs['fn'])
+            -> categories($inputs['category1'])
+            -> categories($inputs['category2'])
+            -> kind($inputs['kind']);
     	return $raithSeinar;
     }
     
@@ -1340,8 +1339,6 @@ class VCardTest extends PHPUnit_Framework_TestCase {
    	$url2 = "baz";
    	$tel  = "999-454-3212";
    	
-   	$vcard =  new vCard();
-   	
    	$vcard  ->url($url1)
    	        ->url($url2)
    	        ->tel($tel);
@@ -1362,4 +1359,3 @@ class VCardTest extends PHPUnit_Framework_TestCase {
    	
    }
 }
-?>

--- a/tests/VCardTest.php
+++ b/tests/VCardTest.php
@@ -628,6 +628,31 @@ class VCardTest extends PHPUnit_Framework_TestCase {
     }
 
     /**
+     * @depends testSetAdrFields
+     */
+    public function testSetAdrType(vCard $vcard)
+    {
+	$address = [
+			'StreetAddress' => '123 Sesame Street',
+			'Locality' => 'Hooville',
+			'Region' => 'Bear-ever',
+			'PostalCode' => '31337',
+			'Country' => 'Elbonia'
+		    ];
+        
+        $vcard->adr($address, 'work');
+	$this->assertNotEmpty($vcard->adr);
+	$this->assertInternalType("array", $vcard->adr);
+	$this->assertCount(1, $vcard->adr, print_r($vcard->adr, true));
+	$this->assertEquals($address, $vcard->adr[0]['Value'], print_r($vcard->adr, true));
+        $this->assertCount(1, $vcard->adr[0]['Type']);
+        $this->assertContains('work', $vcard->adr[0]['Type']);
+	unset($vcard->adr);
+	$this->assertEmpty($vcard->adr);
+	return $vcard;
+    }
+    
+    /**
      * Test ADR fields deprecated by RFC 6350. Should still be supported for the
      * moment.
      * @depends testNoAdr

--- a/vcard.php
+++ b/vcard.php
@@ -509,7 +509,7 @@ class vCard implements \Countable, \Iterator
     public function SaveFile($Key, $Index = 0, $TargetPath = '')
     {
     	assert(null !== $Key);
-    	assert(is_string($key));
+    	assert(is_string($Key));
     	
 	if (!isset($this -> Data[$Key]))
 	{

--- a/vcard.php
+++ b/vcard.php
@@ -76,7 +76,7 @@ class vCard implements \Countable, \Iterator
      * @var array
      */
     private static $Spec_ElementTypes
-        = array(
+        = [
 	    'email' => array('internet', 'x400', 'pref'),
 
 	    'adr' => array( 'dom', 'intl', 'postal', 'parcel',
@@ -95,8 +95,10 @@ class vCard implements \Countable, \Iterator
 
 	    'note' => array( 'home', 'work'),
 
-            'url'  => array('home', 'work')
-        );
+            'url'  => array('home', 'work'),
+            
+            'org'  => array('home', 'work')
+        ];
 
     /**
      * Properties which may contain a BLOB or associated external data.

--- a/vcard.php
+++ b/vcard.php
@@ -607,7 +607,8 @@ class vCard implements \Countable, \Iterator
 	    $Types = array_values(array_slice($Arguments, 1));
 
 	    if ( $this->keyIsStructuredElement($Key)
-                 && in_array($Arguments[1], self::$Spec_StructuredElements[$Key])
+                 && ( in_array($Arguments[1], self::$Spec_StructuredElements[$Key])
+                        || 'Type' === $Arguments[1] )
 	       )
 	    {
 		$LastElementIndex = 0;


### PR DESCRIPTION
This branch contains the last set of changes for Milestone 0.9 by fixing #2 (round-trip DB persistence of TYPE parameter for ORG and ADR). At this point, the package should be in a usable state and should set a path for future improvement. The commentary in #2 and [design diagrams in the Wiki](https://github.com/evought/VCard-Tools/wiki/Object-Model) show where I think it can go from here. Specifically, this isn't just a fork of the original VCard class (which is one reason I did not use the github fork mechanism) but refactoring and expansion into a set of related tools.

As such, I'm inviting @nuovo to look at the package, see if any of the improvements are useful to the original project and perhaps provide feedback. Either way, I have a back-burner project of my own I intend to apply this to.
